### PR TITLE
Fix spellings of Morocco and Moroccan

### DIFF
--- a/full_tacos/moroccan_lamb_taco.md
+++ b/full_tacos/moroccan_lamb_taco.md
@@ -1,9 +1,9 @@
-Morrocoan Lamb Tacos
+Morrocan Lamb Tacos
 ====================
 
 I make a variation of this as meatballs, but the seasoning and flavors are pretty unique.
 
-Base: [Morrocoan Lamb](/base_layers/moroccan_lamb.md)
+Base: [Moroccan Lamb](/base_layers/moroccan_lamb.md)
 
 On top:
 * Chopped onion


### PR DESCRIPTION
Anglicized spelling of "Morocco" (was "Morroco") and "Moroccan" (was "Moroccoan").
