### PR TITLE
Fixed dead link to INDEX.md

### DIFF
--- a/WRITING.md
+++ b/WRITING.md
@@ -18,7 +18,7 @@ File formatting
 Tags
 ----
 * We support tagging of your recipe!
-* Currently the only tags that that we recognize are "vegatarian" and "vegan", they result in a recipe being marked in a (v) in the [index](/index.md)
+* Currently the only tags that that we recognize are "vegatarian" and "vegan", they result in a recipe being marked in a (v) in the [index](/INDEX.md)
 * We require you follow the format:
   * tags: firsttag, secondtag, thirdtag, yougetthepicture
 * If you'd like to add additional tags to your recipe, you can.


### PR DESCRIPTION
On line 21 'index.md' should be in caps as 'INDEX.md'.
A 404 error was given before the fix.
